### PR TITLE
fix clang compiler error on OSX 10.9

### DIFF
--- a/src/singleton/server.cc
+++ b/src/singleton/server.cc
@@ -10,7 +10,7 @@ using boost::recursive_mutex;
 
 server* utilmm::singleton::server::the_instance = 0;
 
-recursive_mutex utilmm::singleton::server::sing_mtx;
+boost::recursive_mutex utilmm::singleton::server::sing_mtx;
 
 /*
  * class utilmm::singleton::server


### PR DESCRIPTION
error: reference to 'recursive_mutex' is ambiguous
recursive_mutex utilmm::singleton::server::sing_mtx;
