### PR TITLE
socket: fix out-of-bounds array write on Mac.

### DIFF
--- a/src/system/socket.cc
+++ b/src/system/socket.cc
@@ -64,8 +64,11 @@ namespace utilmm
 	vector<uint8_t> ret;
 	if (m_domain == Unix)
 	{
+#if __APPLE__
+	    static const unsigned int UNIX_MAX_PATH = 104; // check /usr/include/sys/un.h on Mac
+#else
 	    static const unsigned int UNIX_MAX_PATH = 108;
-
+#endif
 	    if (to.size() >= UNIX_MAX_PATH)
 		throw bad_address();
 


### PR DESCRIPTION
Signed-off-by: Peter Soetens peter@thesourceworks.com
